### PR TITLE
Convert payload values to string for environment variable usage

### DIFF
--- a/codeBuildHandler.py
+++ b/codeBuildHandler.py
@@ -173,7 +173,7 @@ def prepare_codebuild_inputs(body: dict, lambda_env_vars: dict):
         logger.debug(f"env_vars_dict={env_vars_dict}")
         logger.debug(f"type of env_vars_dict: {type(env_vars_dict)}")
         for env_var, json_path in env_vars_dict.items():
-            code_build_env_vars[env_var] = get_value_from_dict(body, json_path)
+            code_build_env_vars[env_var] = str(get_value_from_dict(body, json_path))
         # Add any other Env Vars we want to pass to CodeBuild.
         for key, value in os.environ.items():
             if key.startswith("USERVAR_") or key.startswith("GIT_"):


### PR DESCRIPTION
This adds an explicit conversion to string for all retrieved values from the payload. This fixes an edge case where referencing a non-string payload entry would fail to convert to an environment variable, because the environment variable's value must be a string.